### PR TITLE
Fix startup nib crash

### DIFF
--- a/Example/AFAppDelegate.m
+++ b/Example/AFAppDelegate.m
@@ -16,7 +16,7 @@
 {
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     // Override point for customization after application launch.
-    self.viewController = [[ViewController alloc] initWithNibName:@"AFViewController" bundle:nil];
+    self.viewController = [[ViewController alloc] initWithNibName:@"ViewController" bundle:nil];
     self.window.rootViewController = self.viewController;
     [self.window makeKeyAndVisible];
     return YES;


### PR DESCRIPTION
The app crashes on start, most likely due to some file renaming.
