### PR TITLE
Utilize UIImageView+AFNetworking category methods

### DIFF
--- a/AFProgressiveImageDownload/UIImageView+AFProgressiveImageDownload.m
+++ b/AFProgressiveImageDownload/UIImageView+AFProgressiveImageDownload.m
@@ -35,7 +35,7 @@
     
     __weak typeof(self) weakSelf = self;
     [self setImageWithURLRequest:imageRequest placeholderImage:self.image success:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image) {
-        __weak typeof(weakSelf) strongSelf = weakSelf;
+        __strong typeof(weakSelf) strongSelf = weakSelf;
         if (!strongSelf) {
             return;
         }


### PR DESCRIPTION
This pull request replaces UIImageView+AFProgressiveImageDownload image operations with existing UIImageView+AFNetworking category methods. This allows AFProgressiveImageDownload to take advantage of `af_sharedImageCache`.
